### PR TITLE
fix: Decimal conversion with too many digits for specified scale

### DIFF
--- a/odbc-api/Cargo.toml
+++ b/odbc-api/Cargo.toml
@@ -70,12 +70,12 @@ default=["odbc_version_3_80"]
 # Low level bindings to ODBC API calls into libodbc.so
 odbc-sys = { version = ">= 0.22, < 0.25", default-features = false }
 # Used to generate code for the error type
-thiserror = "1.0.63"
+thiserror = "1.0"
 # Used as a log frontend to emit log messages for applications
-log = "0.4.22"
+log = "0.4"
 # Interacting with UTF-16 texts for wide columns or wide function calls
-widestring = "1.1.0"
-atoi = "2.0.0"
+widestring = "1.1"
+atoi = "2.0"
 odbc-api-derive ={ version = "8.1.2", path = "../derive", optional = true}
 
 [target.'cfg(windows)'.dependencies]

--- a/odbc-api/src/conversion.rs
+++ b/odbc-api/src/conversion.rs
@@ -10,27 +10,35 @@ use atoi::{FromRadix10, FromRadix10Signed};
 /// arbitrary radix character. If you do not write a generic application and now the specific way
 /// your database formats decimals you may come up with faster methods to parse decimals.
 pub fn decimal_text_to_i128(text: &[u8], scale: usize) -> i128 {
-    // High is now the number before the decimal point
-    let (mut high, num_digits_high) = i128::from_radix_10_signed(text);
-    let (low, num_digits_low) = if num_digits_high == text.len() {
+    // lhs is now the number before the decimal point
+    let (mut lhs, num_digits_lhs) = i128::from_radix_10_signed(text);
+    let (rhs, num_digits_rhs) = if num_digits_lhs == text.len() {
         (0, 0)
     } else {
-        i128::from_radix_10(&text[(num_digits_high + 1)..])
+        i128::from_radix_10(&text[(num_digits_lhs + 1)..])
     };
-    // Left shift high so it is compatible with low
-    for _ in 0..num_digits_low {
-        high *= 10;
+    // Left shift lhs so it is compatible with rhs
+    for _ in 0..num_digits_rhs {
+        lhs *= 10;
     }
-    // We want to increase the absolute of high by low without changing highs sign
-    let mut n = if high < 0 || (high == 0 && text[0] == b'-') {
-        high - low
+    // We want to increase the absolute of lhs by rhs without changing lhss sign
+    let mut n = if lhs < 0 || (lhs == 0 && text[0] == b'-') {
+        lhs - rhs
     } else {
-        high + low
+        lhs + rhs
     };
-    // We would be done now, if every database would include trailing zeroes, but they might choose
-    // to omit those. Therfore we see if we need to leftshift n further in order to meet scale.
-    for _ in 0..(scale - num_digits_low) {
-        n *= 10;
+
+    if num_digits_rhs < scale {
+        // We would be done now, if every database would include trailing zeroes, but they might choose
+        // to omit those. Therfore we see if we need to leftshift n further in order to meet scale.
+        for _ in 0..(scale - num_digits_rhs) {
+            n *= 10;
+        }
+    } else {
+        // We need to right shift n to meet scale
+        for _ in 0..(num_digits_rhs - scale) {
+            n /= 10;
+        }
     }
     n
 }
@@ -69,5 +77,11 @@ mod tests {
     fn negative_decimal_small() {
         let actual = decimal_text_to_i128(b"-0.1", 5);
         assert_eq!(-10000, actual);
+    }
+
+    #[test]
+    fn decimal_with_too_much_scale() {
+        let actual = decimal_text_to_i128(b"10.000000", 5);
+        assert_eq!(1_000_000, actual);
     }
 }


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Truncates decimal conversion for situations where the number of RHS digits are more than the specified scale.

For example, when performing an `avg()` query with a decimal source column, the output avg column receives a scale of `(_, 6)` but the actual data received was a decimal with 16 fractional digits (e.g. `12.3456789000000000`). In this example, we truncate the digits to the specified scale for the field leaving behind the actual data of `12.345678`.

## 🔨 Related Issues

* Part of [https://github.com/spiceai/spiceai/issues/1907](https://github.com/spiceai/spiceai/issues/1907)
